### PR TITLE
Adding config option for custom index tpl

### DIFF
--- a/Command/Web/IndexController.php
+++ b/Command/Web/IndexController.php
@@ -19,9 +19,10 @@ class IndexController extends WebController
         $request = $this->getRequest();
 
         if ($this->getApp()->config->site_index !== null) {
+            $indexTpl = $this->getApp()->config->site_index_tpl ?? 'content/single.html.twig';
             $content = $content_provider->fetch($this->getApp()->config->site_index);
             if ($content) {
-                $response = new Response($twig->render('content/single.html.twig', [
+                $response = new Response($twig->render($indexTpl, [
                     'content' => $content
                 ]));
 

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -5,6 +5,10 @@ test('Index page is correctly loaded', function () {
     $app->runCommand(['minicli', 'web', 'index']);
 })->expectOutputRegex("/template listing/");
 
+test('Custom Index page is correctly loaded', function () {
+    $app = getLibrarianIndex("posts/test0");
+    $app->runCommand(['minicli', 'web', 'index']);
+})->expectOutputRegex("/custom index/");
 
 test('Content page posts/test0 is correctly loaded', function () {
     $app = getLibrarianContent('test0');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -47,9 +47,9 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function getLibrarianIndex(): App
+function getLibrarianIndex(string $custom = null): App
 {
-    $app = new App([
+    $config = [
         'app_path' => [
             __DIR__ . '/../Command'
         ],
@@ -57,8 +57,14 @@ function getLibrarianIndex(): App
         'cache_path' => __DIR__ . '/Resources/cache',
         'templates_path' => __DIR__ . '/Resources/templates',
         'debug' => true
-    ]);
+    ];
 
+    if ($custom) {
+        $config['site_index'] = $custom;
+        $config['site_index_tpl'] = "content/custom_index.html.twig";
+    }
+
+    $app = new App($config);
     $router = Mockery::mock(RouterServiceProvider::class);
     $request = Mockery::mock(Request::class);
     $request->shouldReceive('getParams');

--- a/tests/Resources/templates/content/custom_index.html.twig
+++ b/tests/Resources/templates/content/custom_index.html.twig
@@ -1,0 +1,1 @@
+custom index


### PR DESCRIPTION
New config option `site_index_tpl` sets up the template that will be used with the custom `site_index` page. The custom tpl is not mandatory, but when used it requires that you have `site_index` also set.