### PR TITLE
Fixing issue that repeated page after footer

### DIFF
--- a/Command/Web/IndexController.php
+++ b/Command/Web/IndexController.php
@@ -27,6 +27,7 @@ class IndexController extends WebController
                 ]));
 
                 $response->output();
+                return;
             }
         }
 


### PR DESCRIPTION
This should fix a bug where the page was "repeated" after the footer, the missing return statement would make the controller output the listing page after a custom index page was already returned. Reference issue: https://github.com/librarianphp/librarian/issues/36