### PR TITLE
Updating librarian core, now using feed provider to build rss feed

### DIFF
--- a/Command/Web/FeedController.php
+++ b/Command/Web/FeedController.php
@@ -3,6 +3,7 @@
 namespace librarianphp\Web;
 
 use Librarian\Content;
+use Librarian\Provider\FeedServiceProvider;
 use Librarian\WebController;
 use Librarian\Provider\ContentServiceProvider;
 use Suin\RSSWriter\Channel;
@@ -13,38 +14,10 @@ class FeedController extends WebController
 {
     public function handle(): void
     {
-        $feed = new Feed();
-        $channel = new Channel();
-        $channel
-            ->title($this->getApp()->config->site_name)
-            ->description($this->getApp()->config->site_description)
-            ->url($this->getApp()->config->site_url)
-            ->feedUrl($this->getApp()->config->site_url . '/feed')
-            ->language('en-US')
-            ->copyright('Copyright ' . date('Y') . ', '. $this->getApp()->config->site_name)
-            ->pubDate(strtotime(date('Y-m-d H:i:s')))
-            ->lastBuildDate(strtotime(date('Y-m-d H:i:s')))
-            ->ttl(60)
-            ->appendTo($feed);
+        /** @var FeedServiceProvider $feed_provider */
+        $feed_provider = $this->getApp()->feed;
 
-        /** @var ContentServiceProvider $content_provider */
-        $content_provider = $this->getApp()->content;
-        $content_list = $content_provider->fetchAll();
-
-        /** @var Content $content */
-        foreach ($content_list as $content) {
-            $item = new Item();
-            $item
-                ->title($content->title ?? '')
-                ->description('<div>'.($content->description ?? '').'</div>')
-                ->contentEncoded('<div>'.($content->description ?? '').'</div>')
-                ->url($this->getApp()->config->site_url . '/' . $content->getLink())
-                ->author($this->getApp()->config->site_author)
-                ->pubDate(strtotime($content->getDate()))
-                ->guid($this->getApp()->config->site_url . '/' . $content->getLink(), true)
-                ->preferCdata(true) // By this, title and description become CDATA wrapped HTML.
-                ->appendTo($channel);
-        }
+        $feed = $feed_provider->buildFeed();
 
         header('Content-type: application/rss+xml');
         echo $feed;

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     },
     "require": {
         "minicli/minicli": "^4.0",
-        "librarianphp/librarian-core": "^4.0",
-        "suin/php-rss-writer": "^1.6"
+        "librarianphp/librarian-core": "^4.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -271,22 +271,23 @@
         },
         {
             "name": "librarianphp/librarian-core",
-            "version": "4.1.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/librarianphp/librarian-core.git",
-                "reference": "7beb6b39df6a7cc218a33e80396c423ed18cb07a"
+                "reference": "4b32ad438c997128b40adb652459273d71c04800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/librarianphp/librarian-core/zipball/7beb6b39df6a7cc218a33e80396c423ed18cb07a",
-                "reference": "7beb6b39df6a7cc218a33e80396c423ed18cb07a",
+                "url": "https://api.github.com/repos/librarianphp/librarian-core/zipball/4b32ad438c997128b40adb652459273d71c04800",
+                "reference": "4b32ad438c997128b40adb652459273d71c04800",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "librarianphp/parsed": "^1.0",
+                "lukaswhite/php-feed-writer": "^2.0",
                 "minicli/curly": "^0.2.0",
                 "minicli/minicache": "^0.2.0",
                 "minicli/minicli": "^4.0",
@@ -295,6 +296,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.16",
+                "laravel/pint": "^1.10",
                 "pestphp/pest": "^1.0"
             },
             "type": "library",
@@ -311,7 +313,7 @@
             "homepage": "https://github.com/librarianphp/librarian-core",
             "support": {
                 "issues": "https://github.com/librarianphp/librarian-core/issues",
-                "source": "https://github.com/librarianphp/librarian-core/tree/4.1.2"
+                "source": "https://github.com/librarianphp/librarian-core/tree/4.2.0"
             },
             "funding": [
                 {
@@ -319,7 +321,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-06-02T07:35:24+00:00"
+            "time": "2023-06-10T14:50:28+00:00"
         },
         {
             "name": "librarianphp/parsed",
@@ -369,6 +371,51 @@
                 }
             ],
             "time": "2023-05-07T12:45:30+00:00"
+        },
+        {
+            "name": "lukaswhite/php-feed-writer",
+            "version": "2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lukaswhite/php-feed-writer.git",
+                "reference": "a337fc6f6577f87437bafe0a88c1d8128aeeb0ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lukaswhite/php-feed-writer/zipball/a337fc6f6577f87437bafe0a88c1d8128aeeb0ae",
+                "reference": "a337fc6f6577f87437bafe0a88c1d8128aeeb0ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "Lukaswhite\\FeedWriter\\": "src/",
+                    "Lukaswhite\\FeedWriter\\Tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "lukaswhite",
+                    "email": "hello@lukaswhite.com"
+                }
+            ],
+            "description": "A PHP library for writing feeds; e.g. RSS",
+            "support": {
+                "issues": "https://github.com/lukaswhite/php-feed-writer/issues",
+                "source": "https://github.com/lukaswhite/php-feed-writer/tree/2.1"
+            },
+            "time": "2022-07-26T10:34:20+00:00"
         },
         {
             "name": "minicli/curly",
@@ -457,16 +504,16 @@
         },
         {
             "name": "minicli/minicli",
-            "version": "4.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minicli/minicli.git",
-                "reference": "7ccff45d4311e31a2fba896dfe70d4d2c6671aab"
+                "reference": "9879a221df2226df49fa7faacdffc64022dd4070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minicli/minicli/zipball/7ccff45d4311e31a2fba896dfe70d4d2c6671aab",
-                "reference": "7ccff45d4311e31a2fba896dfe70d4d2c6671aab",
+                "url": "https://api.github.com/repos/minicli/minicli/zipball/9879a221df2226df49fa7faacdffc64022dd4070",
+                "reference": "9879a221df2226df49fa7faacdffc64022dd4070",
                 "shasum": ""
             },
             "require": {
@@ -481,6 +528,9 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
                 "psr-4": {
                     "Minicli\\": "src/"
                 }
@@ -497,7 +547,7 @@
             ],
             "support": {
                 "issues": "https://github.com/minicli/minicli/issues",
-                "source": "https://github.com/minicli/minicli/tree/4.0.3"
+                "source": "https://github.com/minicli/minicli/tree/4.0.6"
             },
             "funding": [
                 {
@@ -505,7 +555,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-20T22:04:58+00:00"
+            "time": "2023-06-08T20:27:51+00:00"
         },
         {
             "name": "minicli/stencil",
@@ -1120,16 +1170,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "106c170d08e8415d78be2d16c3d057d0d108262b"
+                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/106c170d08e8415d78be2d16c3d057d0d108262b",
-                "reference": "106c170d08e8415d78be2d16c3d057d0d108262b",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
+                "reference": "7e7d5839d4bec168dfeef0ac66d5c5a2edbabffd",
                 "shasum": ""
             },
             "require": {
@@ -1175,7 +1225,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.6.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -1187,7 +1237,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-03T19:06:57+00:00"
+            "time": "2023-06-08T12:52:13+00:00"
         }
     ],
     "packages-dev": [
@@ -1582,25 +1632,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "8cffffb2218e01f3b370bf763e00e81697725259"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/8cffffb2218e01f3b370bf763e00e81697725259",
-                "reference": "8cffffb2218e01f3b370bf763e00e81697725259",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1619,9 +1673,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2023-05-29T18:55:17+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -2040,38 +2094,44 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.5.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
+                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/13a7fa2642c76c58fa2806ef7f565344c817a191",
+                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.3",
+                "psalm/plugin-phpunit": "^0.18",
+                "vimeo/psalm": "^5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-main": "1.6.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2106,9 +2166,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.1"
+                "source": "https://github.com/mockery/mockery/tree/1.6.2"
             },
-            "time": "2022-09-07T15:32:08+00:00"
+            "time": "2023-06-07T09:07:52+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2409,16 +2469,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v2.6.1",
+            "version": "v2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "faafedd55ca4479b0634f85cc1a68bf5af44764e"
+                "reference": "3c20e8114e5d2f5e39cf013f0f9b8ebc0ac1a6fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/faafedd55ca4479b0634f85cc1a68bf5af44764e",
-                "reference": "faafedd55ca4479b0634f85cc1a68bf5af44764e",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/3c20e8114e5d2f5e39cf013f0f9b8ebc0ac1a6fa",
+                "reference": "3c20e8114e5d2f5e39cf013f0f9b8ebc0ac1a6fa",
                 "shasum": ""
             },
             "require": {
@@ -2426,17 +2486,17 @@
                 "nunomaduro/collision": "^7.5.2",
                 "nunomaduro/termwind": "^1.15.1",
                 "pestphp/pest-plugin": "^2.0.1",
-                "pestphp/pest-plugin-arch": "^2.1.2",
+                "pestphp/pest-plugin-arch": "^2.2.0",
                 "php": "^8.1.0",
-                "phpunit/phpunit": "^10.1.3"
+                "phpunit/phpunit": "^10.2.1"
             },
             "conflict": {
-                "phpunit/phpunit": ">10.1.3",
+                "phpunit/phpunit": ">10.2.1",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
-                "pestphp/pest-dev-tools": "^2.9.0",
-                "symfony/process": "^6.2.10"
+                "pestphp/pest-dev-tools": "^2.10.0",
+                "symfony/process": "^6.3.0"
             },
             "bin": [
                 "bin/pest"
@@ -2492,7 +2552,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v2.6.1"
+                "source": "https://github.com/pestphp/pest/tree/v2.6.3"
             },
             "funding": [
                 {
@@ -2504,7 +2564,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-12T08:22:02+00:00"
+            "time": "2023-06-07T19:19:04+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -2577,27 +2637,27 @@
         },
         {
             "name": "pestphp/pest-plugin-arch",
-            "version": "v2.1.2",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-arch.git",
-                "reference": "485cbfbe2e194e9cfd8284625bd8922c9d27ac6f"
+                "reference": "88725fd0d6ae4025df39c27bd91e98d14b8f1916"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/485cbfbe2e194e9cfd8284625bd8922c9d27ac6f",
-                "reference": "485cbfbe2e194e9cfd8284625bd8922c9d27ac6f",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/88725fd0d6ae4025df39c27bd91e98d14b8f1916",
+                "reference": "88725fd0d6ae4025df39c27bd91e98d14b8f1916",
                 "shasum": ""
             },
             "require": {
-                "nunomaduro/collision": "^7.5.0",
+                "nunomaduro/collision": "^7.5.2",
                 "pestphp/pest-plugin": "^2.0.1",
                 "php": "^8.1",
                 "ta-tikoma/phpunit-architecture-test": "^0.7.3"
             },
             "require-dev": {
-                "pestphp/pest": "^2.5.1",
-                "pestphp/pest-dev-tools": "^2.6.0"
+                "pestphp/pest": "dev-develop as 2.6.2",
+                "pestphp/pest-dev-tools": "^2.10.0"
             },
             "type": "library",
             "autoload": {
@@ -2625,7 +2685,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v2.1.2"
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -2637,7 +2697,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-19T08:48:22+00:00"
+            "time": "2023-06-02T23:15:55+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3287,16 +3347,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.1.3",
+            "version": "10.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d"
+                "reference": "599b33294350e8f51163119d5670512f98b0490d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2379ebafc1737e71cdc84f402acb6b7f04198b9d",
-                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/599b33294350e8f51163119d5670512f98b0490d",
+                "reference": "599b33294350e8f51163119d5670512f98b0490d",
                 "shasum": ""
             },
             "require": {
@@ -3336,7 +3396,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -3368,7 +3428,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.1"
             },
             "funding": [
                 {
@@ -3384,7 +3444,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:16:22+00:00"
+            "time": "2023-06-05T05:15:51+00:00"
         },
         {
             "name": "psr/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "329d8a2a68d8349a1d2a36d5fb540c29",
+    "content-hash": "3389a8d1b914a5d3dc30929a17e67613",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -799,59 +799,6 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
-        },
-        {
-            "name": "suin/php-rss-writer",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/suin/php-rss-writer.git",
-                "reference": "78f45e44a2a7cb0d82e4b9efb6f7b7a075b9051c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/suin/php-rss-writer/zipball/78f45e44a2a7cb0d82e4b9efb6f7b7a075b9051c",
-                "reference": "78f45e44a2a7cb0d82e4b9efb6f7b7a075b9051c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "eher/phpunit": ">=1.6",
-                "mockery/mockery": ">=0.7.2",
-                "suin/xoopsunit": ">=1.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Suin\\RSSWriter": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "suin",
-                    "email": "suinyeze@gmail.com"
-                }
-            ],
-            "description": "Yet another simple RSS writer library for PHP 5.4 or later.",
-            "homepage": "https://github.com/suin/php-rss-writer",
-            "keywords": [
-                "feed",
-                "generator",
-                "php",
-                "rss",
-                "writer"
-            ],
-            "support": {
-                "issues": "https://github.com/suin/php-rss-writer/issues",
-                "source": "https://github.com/suin/php-rss-writer/tree/master"
-            },
-            "time": "2017-07-13T10:47:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -25,10 +25,10 @@
 */
 
 use Librarian\Provider\ContentServiceProvider;
+use Librarian\Provider\FeedServiceProvider;
+use Librarian\Provider\LibrarianServiceProvider;
 use Librarian\Provider\RouterServiceProvider;
 use Librarian\Provider\TwigServiceProvider;
-use Librarian\Provider\LibrarianServiceProvider;
-
 use Librarian\Request;
 use Minicli\App;
 
@@ -77,6 +77,7 @@ function getLibrarianIndex(string $custom = null): App
     $app->addService('twig', new TwigServiceProvider());
     $app->addService('librarian', new LibrarianServiceProvider());
     $app->addService('content', new ContentServiceProvider());
+    $app->addService('feed', new FeedServiceProvider());
 
     $app->librarian->boot();
 
@@ -108,6 +109,7 @@ function getLibrarianContent(string $slug): App
     $app->addService('twig', new TwigServiceProvider());
     $app->addService('librarian', new LibrarianServiceProvider());
     $app->addService('content', new ContentServiceProvider());
+    $app->addService('feed', new FeedServiceProvider());
 
     $app->librarian->boot();
 


### PR DESCRIPTION
If this PR is applied, it will:
- Bumps librarian-core to 4.2.0
- Removes suin/php-rss-writer dependency
- Uses feed provider to build rss feed

P.S. It's part of a serie of other PR's to solve the following issue: https://github.com/librarianphp/librarian/issues/38